### PR TITLE
Implementation of ActiveSource, RequestActiveSource, GiveDeckStatus a…

### DIFF
--- a/types.go
+++ b/types.go
@@ -89,6 +89,15 @@ const (
 	PowerStatusStandbyTransition PowerStatus = 0x03
 )
 
+// Representation of StatusRequest in GiveDeckStatus
+type DeckStatusRequest byte
+
+const (
+	DeckStatusOn   DeckStatusRequest = 0x01
+	DeckStatusOff  DeckStatusRequest = 0x02
+	DeckStatusOnce DeckStatusRequest = 0x02
+)
+
 // Representation of an HDMI CEC opcode.
 type OpCode byte
 


### PR DESCRIPTION
This is what I needed to get my project up and going. Hope you can merge it.
@krynr Any thoughts or problems you see?

Still not able to get the TV to tell me which source is active if my app has just started up. (RequestActiveSource always gives me 0.0.0.0 from my Samsung TV). In my project I need to start a raspberry pi, know if I need to start streaming from an external HLS server. The bandwidth costs pressure me to stop streaming when the pi is not shown on screen. I can listen for RoutingChange, but that only helps if the routing actually changes. If I boot the Pi and the source on the TV is set to the Pi, the Pi cannot detect it. Any thoughts on that? I thought RequestActiveSource would give me the real active source.

https://github.com/krynr/cec/issues/1